### PR TITLE
feat(frontend): implement mobile view detection(a mobile query)

### DIFF
--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -6,7 +6,13 @@ export default function Home() {
   const isMobile = useMobile();
   return (
     <main>
-      <div>{isMobile ? <p>Mobile View</p> : <p>Desktop View</p>}</div>
+      <div>
+         {isMobile ? (
+          <p className="flex items-center justify-center min-h-screen">Mobile View</p>
+        ) : (
+          <p className="flex items-center justify-center min-h-screen">Desktop View</p>
+        )}
+      </div>
     </main>
   );
 }

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -1,9 +1,12 @@
-import Image from 'next/image';
+'use client';
+
+import { useMobile } from '@/lib/utils';
 
 export default function Home() {
+  const isMobile = useMobile();
   return (
     <main>
-      <h1>Hello World</h1>
+      <div>{isMobile ? <p>Mobile View</p> : <p>Desktop View</p>}</div>
     </main>
   );
 }

--- a/apps/frontend/src/lib/utils/index.ts
+++ b/apps/frontend/src/lib/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './cn';
+export * from './useMobile';

--- a/apps/frontend/src/lib/utils/useMobile.ts
+++ b/apps/frontend/src/lib/utils/useMobile.ts
@@ -1,0 +1,25 @@
+// "use client"
+
+import { useEffect, useState } from 'react';
+
+export function useMobile(query: string = '(max-width: 768px)'): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia(query);
+
+    setIsMobile(mediaQuery.matches);
+
+    const handler = (event: MediaQueryListEvent) => {
+      setIsMobile(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handler);
+
+    return () => mediaQuery.removeEventListener('change', handler);
+  }, [query]);
+
+  return isMobile;
+}


### PR DESCRIPTION
This PR introduces a custom React hook — useMobile query — to detect mobile screen sizes dynamically using the browser’s matchMedia.

Details:
Added useMobile hook in utils/ directory.
The hook listens for screen width changes and updates state accordingly.
Ensures SSR safety by checking for the window object before execution.
Default query is set to (max-width: 768px).

Testing: Included a test implementation that conditionally renders mobile-specific components to verify the hook’s functionality.

<img width="317" height="648" alt="image" src="https://github.com/user-attachments/assets/9aac04b8-f611-422a-b48d-2881abad0088" />
<img width="1020" height="654" alt="image" src="https://github.com/user-attachments/assets/1d662e55-5f25-46b7-8e55-9a8d4582299f" />
